### PR TITLE
fix dockerfile bug

### DIFF
--- a/docs/cn/dockerfile_instructions_cn.md
+++ b/docs/cn/dockerfile_instructions_cn.md
@@ -62,9 +62,8 @@ ENV DEBIAN_FRONTEND noninteractive
 ```Bash
 RUN wget https://cnbj2m.fds.api.xiaomi.com/bsp-internal/ROS/open-source-docker-depends/base-deb.tar.gz \
 && tar -xzvf base-deb.tar.gz \
-&& cp base-deb/*.deb /var/cache/apt/archives/ \
-&& apt install --no-install-recommends /var/cache/apt/archives/*.deb \
-&& rm -rf *
+&& cp base-deb/*.deb /var/cache/apt/archives/
+RUN echo y| apt-get install --no-install-recommends /var/cache/apt/archives/*.deb && rm -rf *
 ```
 
 **7.修改pip**

--- a/docs/cn/dockerfile_instructions_cn.md
+++ b/docs/cn/dockerfile_instructions_cn.md
@@ -88,7 +88,7 @@ RUN echo "deb https://mirrors.tuna.tsinghua.edu.cn/ros2/ubuntu/ bionic main" > /
 
 ```Bash
 RUN mkdir carpo-ros2-debs \
-&& wget https://cnbj2m-fds.api.xiaomi.net/bsp-internal/ROS/carpo-ros2-debs/carpo-ros2-debs.tgz \
+&& wget https://cnbj2m.fds.api.xiaomi.com/bsp-internal/ROS/carpo-ros2-debs/carpo-ros2-debs.tgz \
 && tar -xf carpo-ros2-debs.tgz -C carpo-ros2-debs \
 && dpkg -i carpo-ros2-debs/*.deb \
 && rm -rf *


### PR DESCRIPTION
经实验，原文件第六部分不能正常运行通过
![image](https://github.com/MiRoboticsLab/blogs/assets/76079782/ce35ee96-5f78-4541-8585-0483b1e17574)
需作出一下小改动
```
RUN wget https://cnbj2m.fds.api.xiaomi.com/bsp-internal/ROS/open-source-docker-depends/base-deb.tar.gz \
&& tar -xzvf base-deb.tar.gz \
&& cp base-deb/*.deb /var/cache/apt/archives/
RUN echo y| apt-get install --no-install-recommends /var/cache/apt/archives/*.deb && rm -rf *
```
还有网址错误！！！！

原网址无法下载

```
https://cnbj2m.fds.api.xiaomi.com/bsp-internal/ROS/carpo-ros2-debs/carpo-ros2-debs.tgz 
```

修改后可下载
```
 https://cnbj2m.fds.api.xiaomi.com/bsp-internal/ROS/carpo-ros2-debs/carpo-ros2-debs.tgz 
```